### PR TITLE
Allowing percent encoded accented characters in the urls

### DIFF
--- a/public/admin/utils/class-indexnow-url-submission-admin-routes.php
+++ b/public/admin/utils/class-indexnow-url-submission-admin-routes.php
@@ -472,8 +472,14 @@ class BWT_IndexNow_Admin_Routes {
 		if (isset($body)) {
 			$json = json_decode($body);
 			if (isset($json->url) && !empty($json->url)) {
-				$url = sanitize_text_field($json->url);
-				if (empty($url) || !preg_match('/^(https?:\/\/([-\w\.]+)+(:\d+)?(\/([-\w\/_\.]*(\?\S+)?)?)?)$/i', $url, $matches)) {
+				$url = preg_replace_callback(
+					"/%[a-f0-9]{2}/", 
+					function($matches) {
+						return strtoupper($matches[0]);
+					}, 
+					sanitize_url($json->url)
+				);
+				if (empty($url) || filter_var($url, FILTER_VALIDATE_URL) === false) {
 					return new \WP_REST_Response( array(
 						'error' => WP_IN_Errors::InvalidInputUrl
 						), 200 );


### PR DESCRIPTION
As it is now the plugin can't publish URLs containing percent encoded accented characters. Eg.:
/ölbloggen/ is encoded to /%C3%B6lbloggen/ however sanitize_text_field() strips the accented part and submits an invalid url: /lbloggen/ which would potentially lead to a 404 on the search engine part.
What is more the percent encoded pair has to be uppercased hence the usage of preg_replace_callback. 