### PR TITLE
Allow filtering admin user capability type

### DIFF
--- a/public/admin/class-indexnow-url-submission-admin.php
+++ b/public/admin/class-indexnow-url-submission-admin.php
@@ -107,7 +107,7 @@ class BWT_IndexNow_Admin {
 		add_options_page(
 			__('IndexNow Plugin', $this->plugin_name),
 			__('IndexNow', $this->plugin_name),
-			'manage_options',
+			BWT_IndexNow_Admin_Utils::get_admin_capability(),
 			$this->plugin_name,
 			array($this, 'display_plugin_admin_page')
 			);

--- a/public/admin/utils/class-indexnow-url-submission-admin-routes.php
+++ b/public/admin/utils/class-indexnow-url-submission-admin-routes.php
@@ -133,8 +133,8 @@ class BWT_IndexNow_Admin_Routes {
     }
 
 	public function admin_permissions_check( $request ) {
-        return current_user_can( "manage_options" );
-    }
+		return current_user_can( BWT_IndexNow_Admin_Utils::get_admin_capability() );
+	}
 
     public function get_api_key( $request ) {
 		return $this->try_catch($request, array($this, 'call_get_api_key'));

--- a/public/admin/utils/class-indexnow-url-submission-admin-utils.php
+++ b/public/admin/utils/class-indexnow-url-submission-admin-utils.php
@@ -118,6 +118,18 @@ class BWT_IndexNow_Admin_Utils {
 		update_option( 'indexnow-admin_api_key', base64_encode( $api_key ) );
 		update_option( 'indexnow-is_valid_api_key', '1' );
 	}
+
+	/**
+	 * Get the capability name required to access the admin page.
+	 */
+	public static function get_admin_capability() {
+		/**
+		 * Filters the IndexNow admin capability.
+		 *
+		 * @param string $capability Capability slug.
+		 */
+		return apply_filters( 'indexnow_admin_capability', 'manage_options' );
+	}
 }
 
 class IndexNowSubmissionCount {


### PR DESCRIPTION
Oftentimes, custom user roles are defined in WordPress projects to better reflect the editorial workflow. Not always such user roles have the capability to `manage_options` (which is a quite powerful capability).

This change allows filtering the capability name used by the IndexNow admin pages so that WordPress developers working with the plugin have more control.